### PR TITLE
feat: Add Anthropic Claude as AI Provider

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,82 @@
+# BlueJay Onboarding Improvements - TODO
+
+## Implementation Checklist
+
+### Task 1: Add Anthropic Claude as AI Provider
+- [ ] Install @anthropic-ai/sdk dependency
+- [ ] Implement Anthropic client integration
+- [ ] Add to provider selection menu
+- [ ] Support model fetching and selection
+- [ ] Add API key validation
+- [ ] Update all AI routing logic (initAI, isTerminalCommand, determineToolType)
+- [ ] Test with Anthropic API
+- **GitHub Issue:** https://github.com/bvdr/BlueJay/issues/5
+- **Branch:** `feature/anthropic-provider`
+- **Status:** In Progress
+
+### Task 2: Simplify Model Selection (5 Models Per Provider)
+- [ ] Define hardcoded model lists for Anthropic
+- [ ] Define hardcoded model lists for Google Gemini
+- [ ] Define hardcoded model lists for OpenAI
+- [ ] Mark recommended model for each provider
+- [ ] Replace dynamic fetching with static lists
+- [ ] Update model selection UI
+- **GitHub Issue:** [To be created]
+- **Branch:** `feature/simplified-model-selection`
+- **Status:** Not Started
+
+### Task 3: Add Password Masking for API Key Input
+- [ ] Implement secure input with masked characters (••••••)
+- [ ] Apply to OpenAI API key prompt
+- [ ] Apply to Google Gemini API key prompt
+- [ ] Apply to Anthropic API key prompt
+- [ ] Test masking behavior
+- **GitHub Issue:** [To be created]
+- **Branch:** `feature/password-masking`
+- **Status:** Not Started
+
+### Task 4: Add --help Flag Support
+- [ ] Create comprehensive help screen
+- [ ] Add examples and use cases
+- [ ] Include API key links for all 3 providers (OpenAI, Gemini, Anthropic)
+- [ ] Display current configuration status
+- [ ] Handle -h, --help, and help variants
+- **GitHub Issue:** [To be created]
+- **Branch:** `feature/help-command`
+- **Status:** Not Started
+
+### Task 5: Enhance Empty Command Response
+- [ ] Show configuration status prominently
+- [ ] Add contextual guidance based on setup state
+- [ ] Display quick examples for configured users
+- [ ] Guide new users to setup process
+- **GitHub Issue:** [To be created]
+- **Branch:** `feature/enhanced-empty-command`
+- **Status:** Not Started
+
+### Task 6: Improve First-Run Setup Context
+- [ ] Add welcome screen explaining the setup process
+- [ ] Set user expectations (time, requirements)
+- [ ] Show benefits of configuration
+- [ ] Add provider comparison information
+- **GitHub Issue:** [To be created]
+- **Branch:** `feature/setup-context`
+- **Status:** Not Started
+
+### Task 7: Enhance API Key Prompts
+- [ ] Add direct links for OpenAI API keys
+- [ ] Add direct links for Gemini API keys
+- [ ] Add direct links for Anthropic API keys
+- [ ] Include cost estimates per provider
+- [ ] Explain secure storage location
+- **GitHub Issue:** [To be created]
+- **Branch:** `feature/enhanced-api-prompts`
+- **Status:** Not Started
+
+---
+
+## Progress Tracking
+- **Total Tasks:** 7
+- **Completed:** 0
+- **In Progress:** 0
+- **Not Started:** 7

--- a/TODO.md
+++ b/TODO.md
@@ -3,16 +3,17 @@
 ## Implementation Checklist
 
 ### Task 1: Add Anthropic Claude as AI Provider
-- [ ] Install @anthropic-ai/sdk dependency
-- [ ] Implement Anthropic client integration
-- [ ] Add to provider selection menu
-- [ ] Support model fetching and selection
-- [ ] Add API key validation
-- [ ] Update all AI routing logic (initAI, isTerminalCommand, determineToolType)
-- [ ] Test with Anthropic API
+- [x] Install @anthropic-ai/sdk dependency
+- [x] Implement Anthropic client integration
+- [x] Add to provider selection menu
+- [x] Support model fetching and selection
+- [x] Add API key validation
+- [x] Update all AI routing logic (initAI, isTerminalCommand, determineToolType)
+- [x] Test with Anthropic API
 - **GitHub Issue:** https://github.com/bvdr/BlueJay/issues/5
+- **Pull Request:** https://github.com/bvdr/BlueJay/pull/6
 - **Branch:** `feature/anthropic-provider`
-- **Status:** In Progress
+- **Status:** ✅ Completed - Ready to Merge
 
 ### Task 2: Simplify Model Selection (5 Models Per Provider)
 - [ ] Define hardcoded model lists for Anthropic
@@ -77,6 +78,9 @@
 
 ## Progress Tracking
 - **Total Tasks:** 7
-- **Completed:** 0
+- **Completed:** 1
 - **In Progress:** 0
-- **Not Started:** 7
+- **Not Started:** 6
+
+## Completed Tasks
+1. ✅ Task 1: Add Anthropic Claude as AI Provider - PR #6

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.65.0",
         "@clack/prompts": "^0.7.0",
         "@google/generative-ai": "^0.21.0",
         "@octokit/rest": "^19.0.13",
@@ -21,6 +22,33 @@
       },
       "bin": {
         "j": "index.js"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.65.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.65.0.tgz",
+      "integrity": "sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@clack/core": {
@@ -899,6 +927,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1257,6 +1297,11 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/package.json
+++ b/package.json
@@ -49,13 +49,14 @@
     "access": "public"
   },
   "dependencies": {
-    "dotenv": "^16.4.5",
-    "openai": "^4.67.3",
-    "inquirer": "^8.2.6",
-    "chalk": "^4.1.2",
-    "ora": "^5.4.1",
-    "@octokit/rest": "^19.0.13",
+    "@anthropic-ai/sdk": "^0.65.0",
     "@clack/prompts": "^0.7.0",
-    "@google/generative-ai": "^0.21.0"
+    "@google/generative-ai": "^0.21.0",
+    "@octokit/rest": "^19.0.13",
+    "chalk": "^4.1.2",
+    "dotenv": "^16.4.5",
+    "inquirer": "^8.2.6",
+    "openai": "^4.67.3",
+    "ora": "^5.4.1"
   }
 }

--- a/tools/index.js
+++ b/tools/index.js
@@ -12,7 +12,8 @@ const TOOLS = {
 // AI Provider configurations (imported from main)
 const AI_PROVIDERS = {
   OPENAI: 'openai',
-  GEMINI: 'gemini'
+  GEMINI: 'gemini',
+  ANTHROPIC: 'anthropic'
 };
 
 // Determine which tool to use based on user input (works with both OpenAI and Gemini)
@@ -52,6 +53,20 @@ Respond ONLY with the tool identifier, no additional text.`;
       const result = await model.generateContent(prompt);
       const response = await result.response;
       content = response.text().trim();
+    } else if (provider === AI_PROVIDERS.ANTHROPIC) {
+      const response = await aiClient.messages.create({
+        model: 'claude-sonnet-4-5-20250929', // Default model
+        max_tokens: 1024,
+        system: systemPrompt,
+        messages: [
+          {
+            role: 'user',
+            content: userInput
+          }
+        ],
+        temperature: 0.2,
+      });
+      content = response.content[0].text.trim();
     }
 
     if (content.includes('TOOL:TERMINAL')) {


### PR DESCRIPTION
## Summary
Adds Anthropic Claude as a third AI provider option alongside OpenAI and Google Gemini, giving users more flexibility in choosing their preferred AI model.

## Changes
- ✅ Installed @anthropic-ai/sdk dependency
- ✅ Added Anthropic to AI_PROVIDERS constant
- ✅ Implemented checkAnthropicKey() and initAnthropic() functions
- ✅ Added ANTHROPIC_MODELS with 5 Claude models
- ✅ Updated firstRunSetup() to include Anthropic provider option
- ✅ Updated API key management for Anthropic
- ✅ Updated settings menu for provider and model selection
- ✅ Implemented Anthropic API support in isTerminalCommand()
- ✅ Implemented Anthropic API support in determineToolType()

## Available Claude Models
- claude-sonnet-4-5-20250929 (recommended)
- claude-opus-4-20250514
- claude-3-7-sonnet-20250219
- claude-3-5-haiku-20241022
- claude-3-5-sonnet-20241022

## Testing
✅ Tested first-run setup with Anthropic provider
✅ Tested API key entry and storage
✅ Tested model selection
✅ Tested command execution with Claude

## Impact
Users can now choose between OpenAI, Google Gemini, or Anthropic Claude as their AI provider, with full support for API key management, model selection, and command execution.

Fixes #5